### PR TITLE
カテゴリーピックアップの作成

### DIFF
--- a/app/assets/stylesheets/modules/_top.scss
+++ b/app/assets/stylesheets/modules/_top.scss
@@ -83,8 +83,12 @@ max-width:930px;
 }
 .item-header{
   font-size:22px;
-  text-align:center;  
-  margin:26px 11px;
+  text-align:center;
+  margin:26px 330px;
+  white-space: nowrap;
+  a{
+    color:#0099e8;
+    }
   a:hover{
     text-decoration-line: underline;
   }
@@ -143,4 +147,7 @@ max-width:930px;
   font-size:14px;
   text-align:right;
   margin:20;
+  a{
+    color:#0099e8;
+    }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,14 @@ class ItemsController < ApplicationController
   #トップページ 商品一覧
   def index
     @items = Item.all.order("created_at DESC").limit(20)
-    @category_ladies = Category.find(1)
+    lady_ids = Category.find(1).subtree_ids
+    @category_ladies = Item.where(category_id: lady_ids).limit(4)
+    man_ids = Category.find(2).subtree_ids
+    @category_mens = Item.where(category_id: man_ids).limit(4)
+    baby_ids = Category.find(3).subtree_ids
+    @category_babies = Item.where(category_id: baby_ids).limit(4)
+    cosme_ids = Category.find(7).subtree_ids
+    @category_cosmes = Item.where(category_id: cosme_ids).limit(4)
   end
 
   #商品詳細ページ

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,7 @@ class ItemsController < ApplicationController
   #トップページ 商品一覧
   def index
     @items = Item.all.order("created_at DESC").limit(20)
+    @category_ladies = Category.find(1)
   end
 
   #商品詳細ページ

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -9,4 +9,4 @@
   .items-wrapper
     %h3.item-header
     .items-box
-      = render partial: 'items/item',"@items":@items
+      = render partial: 'items/item',collection: @items

--- a/app/views/items/_item-show_btn.html.haml
+++ b/app/views/items/_item-show_btn.html.haml
@@ -11,4 +11,3 @@
     =link_to "https://www.mercari.com/jp/",class:"btn" do
       = fa_icon 'lock',class:'lock'
       = "あんしん・あんぜんへの取り組み"
-    送料込み

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,22 +1,21 @@
-- @items.each do |item|
-  .item-box
-    = link_to item_path(item) do
-      .item-box__photo
-        - item.images.each do |image|
-          = image_tag image.image.url,class: 'item-box__photo'
-          - if item.status == "sold_item"
-            .item-box__badge
-              .item-box__badge__word
-                sold
-          - if item.status == "pause_item"
-            .item-box__badge--gray
-              .item-box__badge--gray__word
-                公開停止中
-      .item-box__text
-        .item-box__text__name 
-          = "#{item.name}"
-        .item-box__text__num
-          .item-box__text__num--price 
-            = "#{item.price}"+"円"
-          .item-box__text__num--like 
-            =fa_icon "heart-o", class: 'icon'
+.item-box
+  = link_to item_path(item) do
+    .item-box__photo
+      - item.images.each do |image|
+        = image_tag image.image.url,class: 'item-box__photo'
+        - if item.status == "sold_item"
+          .item-box__badge
+            .item-box__badge__word
+              sold
+        - if item.status == "pause_item"
+          .item-box__badge--gray
+            .item-box__badge--gray__word
+              公開停止中
+    .item-box__text
+      .item-box__text__name 
+        = "#{item.name}"
+      .item-box__text__num
+        .item-box__text__num--price 
+          = "#{item.price}"+"円"
+        .item-box__text__num--like 
+          =fa_icon "heart-o", class: 'icon'

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -19,32 +19,32 @@
         = image_tag 'banner-camp.jpg', height: '390', width: 'auto', class: 'second-image'
   .pickup-container
     %h2.pickup-head
-      カテゴリーピックアップ
+      ピックアップカテゴリー
       .items-wrapper
-        %h3.item-header  レディース新着アイテム
+        %h3.item-header
+          = link_to "レディース新着アイテム",category_path(1),class:"item-header-blue"
         .items-box
           = render partial: 'item',collection: @category_ladies,as: "item"
         .view-all
-          = link_to "#" do
-            = "すべての商品を見る"
+          = link_to "すべての商品を見る",category_path(1)
       .items-wrapper
-        %h3.item-header  メンズ新着アイテム
+        %h3.item-header
+          = link_to "メンズ新着アイテム",category_path(2),class:"item-header-blue"
         .items-box
           = render partial: 'item',collection: @category_mens,as: "item"
         .view-all
-          = link_to "#" do
-            = "すべての商品を見る"
+          = link_to "すべての商品を見る",category_path(2)
       .items-wrapper
-        %h3.item-header  ベビー・キッズ 新着アイテム
+        %h3.item-header
+          = link_to "ベビー・キッズ 新着アイテム",category_path(3),class:"item-header-blue"
         .items-box
           = render partial: 'item',collection: @category_babies,as: "item"
         .view-all
-          = link_to "#" do
-            = "すべての商品を見る"
+          = link_to "すべての商品を見る",category_path(3)
       .items-wrapper
-        %h3.item-header  コスメ・香水・美容 新着アイテム
+        %h3.item-header
+          = link_to "コスメ・香水・美容 新着アイテム",category_path(7),class:"item-header-blue"
         .items-box
           = render partial: 'item',collection: @category_cosmes,as: "item"
         .view-all
-          = link_to "#" do
-            = "すべての商品を見る"
+          = link_to "すべての商品を見る",category_path(7)

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -23,7 +23,9 @@
       .items-wrapper
         %h3.item-header
         .items-box
-          = render 'item'
+          = render @items
         .view-all
           = link_to "#" do
             = "すべての商品を見る"
+        -# .items-box
+        -#   = render partial: 'item',"@items":@category_ladies

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -19,13 +19,32 @@
         = image_tag 'banner-camp.jpg', height: '390', width: 'auto', class: 'second-image'
   .pickup-container
     %h2.pickup-head
-      商品一覧
+      カテゴリーピックアップ
       .items-wrapper
-        %h3.item-header
+        %h3.item-header  レディース新着アイテム
         .items-box
-          = render @items
+          = render partial: 'item',collection: @category_ladies,as: "item"
         .view-all
           = link_to "#" do
             = "すべての商品を見る"
-        -# .items-box
-        -#   = render partial: 'item',"@items":@category_ladies
+      .items-wrapper
+        %h3.item-header  メンズ新着アイテム
+        .items-box
+          = render partial: 'item',collection: @category_mens,as: "item"
+        .view-all
+          = link_to "#" do
+            = "すべての商品を見る"
+      .items-wrapper
+        %h3.item-header  ベビー・キッズ 新着アイテム
+        .items-box
+          = render partial: 'item',collection: @category_babies,as: "item"
+        .view-all
+          = link_to "#" do
+            = "すべての商品を見る"
+      .items-wrapper
+        %h3.item-header  コスメ・香水・美容 新着アイテム
+        .items-box
+          = render partial: 'item',collection: @category_cosmes,as: "item"
+        .view-all
+          = link_to "#" do
+            = "すべての商品を見る"

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -3,5 +3,4 @@
   .items-wrapper
     %h3.item-header
     .items-box
-      - @items = @search_items
-      = render partial: 'items/item',"@items":@items
+      = render partial: 'items/item',collection: @search_items,as: "item"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -28,13 +28,13 @@
         %tr
           %th カテゴリー
           %td
-            =link_to "#{@item.category.parent.parent.name}","https://www.mercari.com/jp/"
+            =link_to "#{@item.category.root.name}",category_path(@item.category.root)
             %br
             = fa_icon 'arrow-right', class: 'arrow-color'
-            =link_to "#{@item.category.parent.name}","https://www.mercari.com/jp/"
+            =link_to "#{@item.category.parent.name}",category_path(@item.category.parent)
             %br 
             = fa_icon 'arrow-right', class: 'arrow-color'
-            =link_to "#{@item.category.name}","https://www.mercari.com/jp/"
+            =link_to "#{@item.category.name}",category_path(@item.category)
         %tr
           %th ブランド
           %td

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -46,21 +46,22 @@
               = link_to 'ログイン', new_user_session_path, class: 'login-nav__signin'
 
 -# パンくずルート
-.bread-crumbs
-  %ul
-    %li.itemscope
-      - if request.path == '/users'
-        - breadcrumb :mypage
-      - elsif request.path == '/profile'
-        - breadcrumb :profile
-      - elsif request.path == '/address'
-        - breadcrumb :address
-      - elsif request.path == '/pay_way'
-        - breadcrumb :pay_way
-      - elsif request.path == '/mail/password'
-        - breadcrumb :mail_password
-      - elsif request.path == '/users/logout'
-        - breadcrumb :logout
-      - elsif request.path == '/categories'
-        - breadcrumb :categories
-      = breadcrumbs separator: " &rsaquo; "
+- unless request.path == '/'
+  .bread-crumbs
+    %ul
+      %li.itemscope
+        - if request.path == '/users'
+          - breadcrumb :mypage
+        - elsif request.path == '/profile'
+          - breadcrumb :profile
+        - elsif request.path == '/address'
+          - breadcrumb :address
+        - elsif request.path == '/pay_way'
+          - breadcrumb :pay_way
+        - elsif request.path == '/mail/password'
+          - breadcrumb :mail_password
+        - elsif request.path == '/users/logout'
+          - breadcrumb :logout
+        - elsif request.path == '/categories'
+          - breadcrumb :categories
+        = breadcrumbs separator: " &rsaquo; "

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -80,8 +80,11 @@ ActiveRecord::Schema.define(version: 2019_07_26_030434) do
     t.string "last_sign_in_ip"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "provider"
+    t.string "uid"
     t.string "nickname"
-    t.integer "prefecture_id", unsigned: true
+    t.string "token"
+    t.integer "prefecture_id"
     t.string "family_name"
     t.string "first_name"
     t.string "family_name_kana"


### PR DESCRIPTION
# What
・トップページを商品一覧からカテゴリーピックアップに変更
・トップページのカテゴリーのリンクをクリックをした際のルーティングの修正

# Why
ただの商品一覧よりかもカテゴリーに分けたほうが直感的にわかりやすく、ページ遷移もスムーズに行くため。